### PR TITLE
Don't touch the consul binary

### DIFF
--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -28,8 +28,3 @@ ark 'consul' do
   url ::URI.join(node['consul']['base_url'], "#{node['consul']['version']}/", "consul_#{install_version}.zip").to_s
   action :dump
 end
-
-file File.join(node['consul']['install_dir'], 'consul') do
-  mode '0755'
-  action :touch
-end


### PR DESCRIPTION
Touching the consul binary updates the utime, but unzip uses the utime
to determine if it needs to update the binary. As a result, touching the
consul binary will prevent upgrades from happening.
