### PR TITLE
Allow any version of the golang cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -21,6 +21,6 @@ supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 
 depends 'ark'
-depends 'golang', '~> 1.3.0'
+depends 'golang'
 depends 'runit'
 depends 'yum-repoforge'


### PR DESCRIPTION
This avoids conflicts with other cookbooks.
